### PR TITLE
leverage ValidationMonitor and MetricSpec which are introduced in ten…

### DIFF
--- a/udc_metrics.py
+++ b/udc_metrics.py
@@ -2,10 +2,11 @@ import tensorflow as tf
 import functools
 from tensorflow.contrib.learn.python.learn.metric_spec import MetricSpec
 
+
 def create_evaluation_metrics():
     eval_metrics = {}
     for k in [1, 2, 5, 10]:
         eval_metrics["recall_at_%d" % k] = MetricSpec(metric_fn=functools.partial(
             tf.contrib.metrics.streaming_sparse_recall_at_k,
-            k=k), prediction_key="classes")
+            k=k))
     return eval_metrics

--- a/udc_metrics.py
+++ b/udc_metrics.py
@@ -1,10 +1,11 @@
 import tensorflow as tf
 import functools
+from tensorflow.contrib.learn.python.learn.metric_spec import MetricSpec
 
 def create_evaluation_metrics():
-  eval_metrics = {}
-  for k in [1, 2, 5, 10]:
-    eval_metrics["recall_at_%d" % k] = functools.partial(
-        tf.contrib.metrics.streaming_sparse_recall_at_k,
-        k=k)
-  return eval_metrics
+    eval_metrics = {}
+    for k in [1, 2, 5, 10]:
+        eval_metrics["recall_at_%d" % k] = MetricSpec(metric_fn=functools.partial(
+            tf.contrib.metrics.streaming_sparse_recall_at_k,
+            k=k), prediction_key="classes")
+    return eval_metrics

--- a/udc_train.py
+++ b/udc_train.py
@@ -52,18 +52,12 @@ def main(unused_argv):
     num_epochs=1)
 
   eval_metrics = udc_metrics.create_evaluation_metrics()
-
-  # We need to subclass theis manually for now. The next TF version will
-  # have support ValidationMonitors with metrics built-in.
-  # It's already on the master branch.
-  class EvaluationMonitor(tf.contrib.learn.monitors.EveryN):
-    def every_n_step_end(self, step, outputs):
-      self._estimator.evaluate(
+  
+  eval_monitor = tf.contrib.learn.monitors.ValidationMonitor(
         input_fn=input_fn_eval,
-        metrics=eval_metrics,
-        steps=None)
+        every_n_steps=FLAGS.eval_every,
+        metrics=eval_metrics)
 
-  eval_monitor = EvaluationMonitor(every_n_steps=FLAGS.eval_every, first_n_steps=-1)
   estimator.fit(input_fn=input_fn_train, steps=None, monitors=[eval_monitor])
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the current code base, it mentioned about ValidationMonitor in v0.11.x. Since v0.11 is released, leverage this class.

Also, MetricSpec is used to generate evaluation metrics. But here, is it correct to create metrics like this, I am not very sure. Especially the **prediction_key**.

```
eval_metrics["recall_at_%d" % k] = MetricSpec(metric_fn=functools.partial(
            tf.contrib.metrics.streaming_sparse_recall_at_k,
            k=k), prediction_key="classes")
```