### PR TITLE
Update helpers.py

### DIFF
--- a/models/helpers.py
+++ b/models/helpers.py
@@ -40,3 +40,4 @@ def build_initial_embedding_matrix(vocab_dict, glove_dict, glove_vectors, embedd
   for word, glove_word_idx in glove_dict.items():
     word_idx = vocab_dict.get(word)
     initial_embeddings[word_idx, :] = glove_vectors[glove_word_idx]
+  return initial_embeddings


### PR DESCRIPTION
build_initial_embedding_matrix should return initial_embeddings so that the existing word vectors is taken into account by the application.  Otherwise, the initializer is set to None, hence, the word vectors are randomly populated even if we integrated external word vectors such as GloVe or Word2Vec.